### PR TITLE
Add lxml to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyqt5==5.9.2
 html2text
 pyperclip
+lxml


### PR DESCRIPTION
Current requirements.txt does not include lxml even though it is used by the application

Side note, it works really well on Mac OS too!